### PR TITLE
Use variable `str` in readme example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ const str = '\tunicorn\n\t\tcake';
 		cake
 */
 
-stripIndent('\tunicorn\n\t\tcake');
+stripIndent(str);
 /*
 unicorn
 	cake


### PR DESCRIPTION
I thought it would be more consistent to use the variable name in the readme example rather than the string duplicated.