### PR TITLE
Add testString parameter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,6 @@ stripIndent(string);
 //	cake
 ```
 */
-declare function stripIndent(string: string): string;
+declare function stripIndent(string: string, testString?: string): string;
 
 export = stripIndent;

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
 const minIndent = require('min-indent');
 
-module.exports = string => {
-	const indent = minIndent(string);
+module.exports = (string, testString = string) => {
+	const indent = minIndent(testString);
 
 	if (indent === 0) {
 		return string;

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,13 @@ unicorn
 */
 ```
 
+You can pass a different string for indentation detection. Useful if your string may contain only whitespaces (like manipulating `node.raws.before` in a [PostCSS](https://github.com/postcss/postcss) plugin):
+
+```js
+const string = '\n\t';
+const testString = '\tunicorn\n\t\tcake';
+stripIndent(string, testString); // '\n'
+```
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -7,3 +7,9 @@ test('main', t => {
 	t.is(stripIndent('\t\t<!doctype html>\n\t\t<html>\n\t\t\t<body>\n\n\n\n\t\t\t\t<h1>Hello world!</h1>\n\t\t\t</body>\n\t\t</html>'), '<!doctype html>\n<html>\n\t<body>\n\n\n\n\t\t<h1>Hello world!</h1>\n\t</body>\n</html>');
 	t.is(stripIndent('\n\t\n\t\tunicorn\n\n\n\n\t\t\tunicorn'), '\n\t\nunicorn\n\n\n\n\tunicorn', 'ignore whitespace only lines');
 });
+
+test('different test string', t => {
+	t.is(stripIndent('\n\t', '\n\tunicorn\n'), '\n');
+	t.is(stripIndent('\n\tunicorn\n\t\tunicorn\n', '\n\tunicorn\n'), '\nunicorn\n\tunicorn\n');
+	t.is(stripIndent('\n\tunicorn\n', '\nunicorn\n'), '\n\tunicorn\n');
+});


### PR DESCRIPTION
Hi Sindre,

It would be a nice-to-have option to specify a different test string to detect the indentation. If the main string is whitespace-only or kind of broken, it won't work.

My use case: I am now writing a postCSS plugin that unwraps a container, and can only change the `node.raws.before` (usually some newlines and spaces/tabs) - so need a different source to analyse the indentation.

Hope it does not break the simplicity.

Cheers,
Bartosz