### PR TITLE
Add `count` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,10 @@
 declare namespace stripIndent {
-  interface Options {
-    /**
+	interface Options {
+		/**
 		Whitespace number to be stripped. Determined automatically if not specified.
 		*/
-    readonly indent?: number;
-  }
+		readonly indent?: number;
+	}
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,16 @@
+declare namespace stripIndent {
+  interface Options {
+    /**
+		Whitespace number to be stripped. Determined automatically if not specified.
+		*/
+    readonly indent?: number;
+  }
+}
+
 /**
 Strip leading whitespace from each line in a string.
 
-The line with the least number of leading whitespace, ignoring empty lines, determines the number to remove.
+The line with the least number of leading whitespace, ignoring empty lines, determines the number to remove (unless specified in options).
 
 @example
 ```
@@ -16,6 +25,6 @@ stripIndent(string);
 //	cake
 ```
 */
-declare function stripIndent(string: string): string;
+declare function stripIndent(string: string, options?: stripIndent.Options): string;
 
 export = stripIndent;

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
 const minIndent = require('min-indent');
 
-module.exports = string => {
-	const indent = minIndent(string);
+module.exports = (string, options = {}) => {
+	const indent = options.indent === undefined ? minIndent(string) : options.indent;
 
 	if (indent === 0) {
 		return string;

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ Type: `object`
 
 ##### indent
 
-Type: `string`
+Type: `number`
 
 Whitespace number to be stripped. Determined automatically if not specified.
 

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ unicorn
 
 ## API
 
-### stripIndent(string, [options])
+### stripIndent(string, options?)
 
 Returns a `string`.
 
@@ -44,9 +44,10 @@ Type: `object`
 
 ##### indent
 
-Type: `number`
+Type: `number`\
+Default: The line with the least amount of leading whitespace, ignoring empty lines, determines the number.
 
-Whitespace number to be stripped. Determined automatically if not specified.
+Whitespace number to be stripped.
 
 ## Advanced usage
 

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,36 @@ unicorn
 */
 ```
 
+## API
+
+### stripIndent(string, [options])
+
+Returns a `string`.
+
+#### options
+
+Type: `object`
+
+##### indent
+
+Type: `string`
+
+Whitespace number to be stripped. Determined automatically if not specified.
+
+## Advanced usage
+
+Passing `indent` option: useful if the string may contain only whitespaces (like manipulating `node.raws.before` in a [PostCSS](https://github.com/postcss/postcss) plugin) or for optimization. Check the indentation first for the context using e.g. [min-indent](https://github.com/jamiebuilds/min-indent) and use this module to just strip it.
+
+```js
+const minIndent = require('min-indent');
+const stripIndent = require('strip-indent');
+
+const fullString = '\tunicorn\n\t\tcake';
+const string = '\n\t\t';
+const indent = minIndent(fullString);
+
+stripIndent(string, {indent}); // '\n\t'
+```
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -7,3 +7,9 @@ test('main', t => {
 	t.is(stripIndent('\t\t<!doctype html>\n\t\t<html>\n\t\t\t<body>\n\n\n\n\t\t\t\t<h1>Hello world!</h1>\n\t\t\t</body>\n\t\t</html>'), '<!doctype html>\n<html>\n\t<body>\n\n\n\n\t\t<h1>Hello world!</h1>\n\t</body>\n</html>');
 	t.is(stripIndent('\n\t\n\t\tunicorn\n\n\n\n\t\t\tunicorn'), '\n\t\nunicorn\n\n\n\n\tunicorn', 'ignore whitespace only lines');
 });
+
+test('indent option specified', t => {
+	t.is(stripIndent('\n\t', {indent: 1}), '\n');
+	t.is(stripIndent('\n\tunicorn\n\t\tunicorn\n', {indent: 1}), '\nunicorn\n\tunicorn\n');
+	t.is(stripIndent('\n\tunicorn\n', {indent: 0}), '\n\tunicorn\n');
+});

--- a/test.js
+++ b/test.js
@@ -8,7 +8,7 @@ test('main', t => {
 	t.is(stripIndent('\n\t\n\t\tunicorn\n\n\n\n\t\t\tunicorn'), '\n\t\nunicorn\n\n\n\n\tunicorn', 'ignore whitespace only lines');
 });
 
-test('indent option specified', t => {
+test('`indent` option', t => {
 	t.is(stripIndent('\n\t', {indent: 1}), '\n');
 	t.is(stripIndent('\n\tunicorn\n\t\tunicorn\n', {indent: 1}), '\nunicorn\n\tunicorn\n');
 	t.is(stripIndent('\n\tunicorn\n', {indent: 0}), '\n\tunicorn\n');


### PR DESCRIPTION
A follow-up for #8. Adds an option to specify number of whitespace manually. It is better than passing the string, since we can check the number once and then apply several times.

(from the original PR) My use case: I am now writing a PostCSS plugin that unwraps a container, and can only change the `node.raws.before` (usually some newlines and spaces/tabs) - so need a different source to analyse the indentation.

Other scenario: optimize multiple runs, checking the indentation number only once and then only applying.

Cheers,
Bartosz